### PR TITLE
File encoding and CRLFs

### DIFF
--- a/pyclarity_lims/lims.py
+++ b/pyclarity_lims/lims.py
@@ -92,15 +92,14 @@ class Lims(object):
     def get_file_contents(self, id=None, uri=None, encoding=None, crlf=False):
         """Returns the contents of the file of <ID> or <uri>"""
         if id:
-            segments = ['api', self.VERSION, 'files', id, 'download']
+            url = self.get_uri('files', id, 'download')
         elif uri:
-            segments = [uri, 'download']
+            url = uri.rstrip('/') + '/download'
         else:
-            raise ValueError("id or uri required")
-        url = urljoin(self.baseuri, '/'.join(segments))
+            raise ValueError('id or uri required')
+
         r = self.request_session.get(url, auth=(self.username, self.password), timeout=TIMEOUT)
         self.validate_response(r)
-
         if encoding:
             r.encoding = encoding
 

--- a/pyclarity_lims/lims.py
+++ b/pyclarity_lims/lims.py
@@ -89,7 +89,7 @@ class Lims(object):
         else:
             return self.parse_response(r)
 
-    def get_file_contents(self, id=None, uri=None):
+    def get_file_contents(self, id=None, uri=None, encoding=None, crlf=False):
         """Returns the contents of the file of <ID> or <uri>"""
         if id:
             segments = ['api', self.VERSION, 'files', id, 'download']
@@ -100,7 +100,11 @@ class Lims(object):
         url = urljoin(self.baseuri, '/'.join(segments))
         r = self.request_session.get(url, auth=(self.username, self.password), timeout=TIMEOUT)
         self.validate_response(r)
-        return r.text
+
+        if encoding:
+            r.encoding = encoding
+
+        return r.text.replace('\r\n', '\n') if crlf else r.text
 
     def upload_new_file(self, entity, file_to_upload):
         """Upload a file and attach it to the provided entity."""

--- a/tests/test_lims.py
+++ b/tests/test_lims.py
@@ -1,4 +1,3 @@
-import xml
 from unittest import TestCase
 
 from requests.exceptions import HTTPError
@@ -19,6 +18,7 @@ else:
     from unittest.mock import patch, Mock
     import builtins
 
+
 class TestLims(TestCase):
     url = 'http://testgenologics.com:4040'
     username = 'test'
@@ -36,11 +36,9 @@ class TestLims(TestCase):
 <exc:exception xmlns:exc="http://pyclarity_lims.com/ri/exception">
 </exc:exception>"""
 
-
     def test_get_uri(self):
         lims = Lims(self.url, username=self.username, password=self.password)
         assert lims.get_uri('artifacts',sample_name='test_sample') == '{url}/api/v2/artifacts?sample_name=test_sample'.format(url=self.url)
-
 
     def test_parse_response(self):
         lims = Lims(self.url, username=self.username, password=self.password)
@@ -55,7 +53,6 @@ class TestLims(TestCase):
 
         r = Mock(content = self.error_no_msg_xml, status_code=400)
         self.assertRaises(HTTPError, lims.parse_response, r)
-
 
     @patch('requests.Session.get',return_value=Mock(content = sample_xml, status_code=200))
     def test_get(self, mocked_instance):
@@ -87,7 +84,6 @@ class TestLims(TestCase):
         with patch('requests.post', return_value=Mock(content = self.error_xml, status_code=400)) as mocked_put:
             self.assertRaises(HTTPError, lims.post, uri=uri, data=self.sample_xml)
             assert mocked_put.call_count == 1
-
 
     @patch('os.path.isfile', return_value=True)
     @patch.object(builtins, 'open')
@@ -124,8 +120,6 @@ class TestLims(TestCase):
         lims.route_artifacts(artifact_list=[artifact], workflow_uri=self.url+'/api/v2/configuration/workflows/1')
         assert mocked_post.call_count == 1
 
-
-
     def test_tostring(self):
         lims = Lims(self.url, username=self.username, password=self.password)
         from xml.etree import ElementTree as ET
@@ -139,5 +133,16 @@ class TestLims(TestCase):
         string = lims.tostring(etree)
         assert string == expected_string
 
+    @patch('pyclarity_lims.lims.urljoin', return_value='a_url')
+    def test_get_file_contents(self, mocked_urljoin):
+        lims = Lims(self.url, username=self.username, password=self.password)
+        lims.validate_response = Mock()
+        lims.request_session = Mock(get=Mock(return_value=Mock(encoding=None, text='some data\r\n')))
 
+        assert lims.get_file_contents(id='an_id') == 'some data\r\n'
+        assert lims.request_session.get.return_value.encoding is None
 
+        assert lims.get_file_contents(id='an_id', encoding='utf-16', crlf=True) == 'some data\n'
+        assert lims.request_session.get.return_value.encoding == 'utf-16'
+
+        mocked_urljoin.assert_called_with('http://testgenologics.com:4040/', 'api/v2/files/an_id/download')

--- a/tests/test_lims.py
+++ b/tests/test_lims.py
@@ -133,16 +133,16 @@ class TestLims(TestCase):
         string = lims.tostring(etree)
         assert string == expected_string
 
-    @patch('pyclarity_lims.lims.urljoin', return_value='a_url')
-    def test_get_file_contents(self, mocked_urljoin):
+    def test_get_file_contents(self):
         lims = Lims(self.url, username=self.username, password=self.password)
         lims.validate_response = Mock()
         lims.request_session = Mock(get=Mock(return_value=Mock(encoding=None, text='some data\r\n')))
+        exp_url = self.url + '/api/v2/files/an_id/download'
 
-        assert lims.get_file_contents(id='an_id') == 'some data\r\n'
+        assert lims.get_file_contents(uri=self.url + '/api/v2/files/an_id') == 'some data\r\n'
         assert lims.request_session.get.return_value.encoding is None
+        lims.request_session.get.assert_called_with(exp_url, auth=(self.username, self.password), timeout=16)
 
         assert lims.get_file_contents(id='an_id', encoding='utf-16', crlf=True) == 'some data\n'
         assert lims.request_session.get.return_value.encoding == 'utf-16'
-
-        mocked_urljoin.assert_called_with('http://testgenologics.com:4040/', 'api/v2/files/an_id/download')
+        lims.request_session.get.assert_called_with(exp_url, auth=(self.username, self.password), timeout=16)


### PR DESCRIPTION
When a `requests` response object's `text` property is called, `self.encoding` is applied to `self.content`. Usually this is `None` and falls back to `self.apparent_encoding`.

In a case we were seeing though, a UTF-16-encoded XML file from a Windows machine was breaking this: since the `Content-Type` response header contained the string `text`, ISO-8859-1 encoding was being applied (see http://docs.python-requests.org/en/latest/user/advanced/?highlight=encoding#encodings).

Closes #10 by adding optional encodings and ability to convert CRLFs to `\n`.
