### PR TITLE
Queued artifacts

### DIFF
--- a/pyclarity_lims/descriptors.py
+++ b/pyclarity_lims/descriptors.py
@@ -721,6 +721,40 @@ class ExternalidList(XmlList):
         list.append(self, (element.attrib.get('id'), element.attrib.get('uri')))
 
 
+class QueuedArtifactList(TagXmlList):
+    """This is a list of Artifact associated with the time they spent in the queue and their location on a plate.
+    The list contains tuples organise as follow:
+        (A, B, (C, D)) where
+         A is an artifact
+         B is a datetime object,
+         C is a container
+         D is a string specifying the location such as "1:1"
+        """
+
+    def __init__(self, instance, *args, **kwargs):
+        TagXmlList.__init__(self, instance, tag='artifact', nesting=['artifacts'], *args, **kwargs)
+
+    def _parse_element(self, element, lims, **kwargs):
+        from pyclarity_lims.entities import Artifact, Container
+        input = Artifact(lims, uri=element.attrib['uri'])
+        loc = element.find('location')
+        location = (None, None)
+        if loc:
+            location = (
+                Container(lims, uri=loc.find('container').attrib['uri']),
+                loc.find('value').text
+            )
+        qt = element.find('queue-time')
+        queue_date = None
+        if qt is not None:
+            h, s, t = qt.text.rpartition(':')
+            try:
+                queue_date = datetime.datetime.strptime(h+t, '%Y-%m-%dT%H:%M:%S.%f%z')
+            except ValueError:
+                queue_date = datetime.datetime.strptime(h + t, '%Y-%m-%dT%H:%M:%S%z')
+        list.append(self, (input, queue_date, location))
+
+
 # Descriptors: This section contains the object that can be used in entities
 class BaseDescriptor(XmlElement):
     """Abstract base descriptor for an instance attribute."""

--- a/pyclarity_lims/descriptors.py
+++ b/pyclarity_lims/descriptors.py
@@ -748,10 +748,18 @@ class QueuedArtifactList(TagXmlList):
         queue_date = None
         if qt is not None:
             h, s, t = qt.text.rpartition(':')
+            qt = h + t
+            microsec = ''
+            if '.' in qt:
+                microsec = '.%f'
+            date_format = '%Y-%m-%dT%H:%M:%S' + microsec
             try:
-                queue_date = datetime.datetime.strptime(h+t, '%Y-%m-%dT%H:%M:%S.%f%z')
+                queue_date = datetime.datetime.strptime(qt, date_format + '%z')
             except ValueError:
-                queue_date = datetime.datetime.strptime(h + t, '%Y-%m-%dT%H:%M:%S%z')
+                # support for python 2.7 ignore time zone
+                # use python 3 for timezone support
+                qt = qt.split('+')[0]
+                queue_date = datetime.datetime.strptime(qt, date_format)
         list.append(self, (input, queue_date, location))
 
 

--- a/pyclarity_lims/descriptors.py
+++ b/pyclarity_lims/descriptors.py
@@ -736,7 +736,7 @@ class QueuedArtifactList(TagXmlList):
 
     def _parse_element(self, element, lims, **kwargs):
         from pyclarity_lims.entities import Artifact, Container
-        input = Artifact(lims, uri=element.attrib['uri'])
+        input_art = Artifact(lims, uri=element.attrib['uri'])
         loc = element.find('location')
         location = (None, None)
         if loc:
@@ -760,7 +760,7 @@ class QueuedArtifactList(TagXmlList):
                 # use python 3 for timezone support
                 qt = qt.split('+')[0]
                 queue_date = datetime.datetime.strptime(qt, date_format)
-        list.append(self, (input, queue_date, location))
+        list.append(self, (input_art, queue_date, location))
 
 
 # Descriptors: This section contains the object that can be used in entities

--- a/pyclarity_lims/entities.py
+++ b/pyclarity_lims/entities.py
@@ -5,7 +5,7 @@ from pyclarity_lims.descriptors import StringDescriptor, UdfDictionaryDescriptor
     InputOutputMapList, LocationDescriptor, IntegerAttributeDescriptor, \
     StringAttributeDescriptor, EntityListDescriptor, StringListDescriptor, PlacementDictionaryDescriptor, \
     ReagentLabelList, AttributeListDescriptor, StringDictionaryDescriptor, OutputPlacementListDescriptor, \
-    XmlActionList, MutableDescriptor, XmlPooledInputDict
+    XmlActionList, MutableDescriptor, XmlPooledInputDict, QueuedArtifactList
 
 try:
     from urllib.parse import urlsplit, urlparse, parse_qs, urlunparse
@@ -1041,13 +1041,28 @@ class ReagentType(Entity):
                         self.sequence = child.attrib.get("value")
 
 class Queue(Entity):
-    """Queue of a given step"""
+    """Queue of a given workflow stage"""
     _URI = "queues"
     _TAG= "queue"
     _PREFIX = "que"
 
-    artifacts = EntityListDescriptor("artifact", Artifact, nesting=["artifacts"])
-    """List of :py:class:`artifacts <pyclarity_lims.entities.Artifact>` associated with this workflow."""
+    queued_artifacts = MutableDescriptor(QueuedArtifactList)
+    """
+    List of :py:class:`artifacts <pyclarity_lims.entities.Artifact>` associated with this workflow stage.
+    alongside the time the've been added to that queue and the container they're in.
+    The list contains tuples organise as follow:
+        (A, B, (C, D)) where
+         A is an :py:class:`artifacts <pyclarity_lims.entities.Artifact>`
+         B is a :py:class:`datetime <datetime.datetime>` object,
+         C is a :py:class:`container <pyclarity_lims.entities.Container>`
+         D is a string specifying the location such as "1:1"
+    """
+
+    @property
+    def artifacts(self):
+        """List of :py:class:`artifacts <pyclarity_lims.entities.Artifact>` associated with this workflow stage."""
+        return [i[0] for i in self.queued_artifacts]
+
 
 Sample.artifact = EntityDescriptor('artifact', Artifact)
 StepActions.step = EntityDescriptor('step', Step)

--- a/tests/test_descriptors.py
+++ b/tests/test_descriptors.py
@@ -772,28 +772,13 @@ class TestQueuedArtifactList(TestCase):
 
     def test_parse(self):
         queued_artifacts = QueuedArtifactList(self.instance1)
-        # qart = (
-        #     Artifact(self.lims, id='a1'),
-        #     datetime.datetime(2011, 12, 25, 1, 10, 10, 50000, tzinfo=datetime.timezone.utc),
-        #     (Container(self.lims, id='c1'), 'A:1')
-        # )
         qart = self.get_queue_art('a1', 'A:1', 50000, datetime.timedelta(0, 0))
         assert queued_artifacts[0] == qart
-        # qart = (
-        #     Artifact(self.lims, id='a2'),
-        #     datetime.datetime(2011, 12, 25, 1, 10, 10, 200000, tzinfo=datetime.timezone(datetime.timedelta(second=3600))),
-        #     (Container(self.lims, id='c1'), 'A:2')
-        # )
         qart = self.get_queue_art('a2', 'A:2', 200000, datetime.timedelta(0, 3600))
         assert queued_artifacts[1] == qart
 
     def test_set(self):
         queued_artifacts = QueuedArtifactList(self.instance1)
-        # qart = (
-        #     Artifact(self.lims, id='a3'),
-        #     datetime.datetime(2011, 12, 25, 1, 10, 11, 50000, tzinfo=datetime.timezone.utc),
-        #     (Container(self.lims, id='c1'), 'A:3')
-        # )
         qart = self.get_queue_art('a1', 'A:3',  50000, datetime.timedelta(0, 0))
         with pytest.raises(NotImplementedError):
             queued_artifacts.append(qart)

--- a/tests/test_descriptors.py
+++ b/tests/test_descriptors.py
@@ -756,28 +756,45 @@ class TestQueuedArtifactList(TestCase):
         self.lims = Lims('http://testgenologics.com:4040', username='test', password='password')
         self.instance1 = Mock(root=et, lims=self.lims)
 
+    def get_queue_art(self, art_id, pos, microsec, time_delta):
+        if version_info[0] == 2:
+            return (
+                Artifact(self.lims, id=art_id),
+                datetime.datetime(2011, 12, 25, 1, 10, 10, microsec),
+                (Container(self.lims, id='c1'), pos)
+            )
+        else:
+            return (
+                Artifact(self.lims, id=art_id),
+                datetime.datetime(2011, 12, 25, 1, 10, 10, microsec, tzinfo=datetime.timezone(time_delta)),
+                (Container(self.lims, id='c1'), pos)
+            )
+
     def test_parse(self):
         queued_artifacts = QueuedArtifactList(self.instance1)
-        qart = (
-            Artifact(self.lims, id='a1'),
-            datetime.datetime(2011, 12, 25, 1, 10, 10, 50000, tzinfo=datetime.timezone.utc),
-            (Container(self.lims, id='c1'), 'A:1')
-        )
+        # qart = (
+        #     Artifact(self.lims, id='a1'),
+        #     datetime.datetime(2011, 12, 25, 1, 10, 10, 50000, tzinfo=datetime.timezone.utc),
+        #     (Container(self.lims, id='c1'), 'A:1')
+        # )
+        qart = self.get_queue_art('a1', 'A:1', 50000, datetime.timedelta(0, 0))
         assert queued_artifacts[0] == qart
-        qart = (
-            Artifact(self.lims, id='a2'),
-            datetime.datetime(2011, 12, 25, 1, 10, 10, 200000, tzinfo=datetime.timezone(datetime.timedelta(0, 3600))),
-            (Container(self.lims, id='c1'), 'A:2')
-        )
+        # qart = (
+        #     Artifact(self.lims, id='a2'),
+        #     datetime.datetime(2011, 12, 25, 1, 10, 10, 200000, tzinfo=datetime.timezone(datetime.timedelta(second=3600))),
+        #     (Container(self.lims, id='c1'), 'A:2')
+        # )
+        qart = self.get_queue_art('a2', 'A:2', 200000, datetime.timedelta(0, 3600))
         assert queued_artifacts[1] == qart
 
     def test_set(self):
         queued_artifacts = QueuedArtifactList(self.instance1)
-        qart = (
-            Artifact(self.lims, id='a3'),
-            datetime.datetime(2011, 12, 25, 1, 10, 11, 50000, tzinfo=datetime.timezone.utc),
-            (Container(self.lims, id='c1'), 'A:3')
-        )
+        # qart = (
+        #     Artifact(self.lims, id='a3'),
+        #     datetime.datetime(2011, 12, 25, 1, 10, 11, 50000, tzinfo=datetime.timezone.utc),
+        #     (Container(self.lims, id='c1'), 'A:3')
+        # )
+        qart = self.get_queue_art('a1', 'A:3',  50000, datetime.timedelta(0, 0))
         with pytest.raises(NotImplementedError):
             queued_artifacts.append(qart)
 


### PR DESCRIPTION
Properly parse the queued artifacts to retrieve the artifacts and the timed they were queued.
`queued_artifacts` returns a`list` of `tuple` such as:
```python
queued_artifacts =  [
    (Artifact(), datetime(...), (Container(), 'H11')),
    (Artifact(), datetime(...), (Container(), 'H12')), 
]
```
In python 3 the datetime object will have a time zone where it will be ignored in python 2.7 
closes #18 