### PR TITLE
fixing issue for python 2.7 where timezone is - GMT and not + GMT

### DIFF
--- a/pyclarity_lims/descriptors.py
+++ b/pyclarity_lims/descriptors.py
@@ -762,7 +762,7 @@ class QueuedArtifactList(TagXmlList):
                     qt = qt.split('+')[0]
                 else:
                     qt_array = qt.split('-')
-                    qt = qt_array[0] + qt_array[1] + qt_array[2]
+                    qt = qt_array[0] + "-" + qt_array[1] + "-" + qt_array[2]
                 queue_date = datetime.datetime.strptime(qt, date_format)
         list.append(self, (input_art, queue_date, location))
 

--- a/pyclarity_lims/descriptors.py
+++ b/pyclarity_lims/descriptors.py
@@ -758,7 +758,11 @@ class QueuedArtifactList(TagXmlList):
             except ValueError:
                 # support for python 2.7 ignore time zone
                 # use python 3 for timezone support
-                qt = qt.split('+')[0]
+                if '+' in qt:
+                    qt = qt.split('+')[0]
+                else:
+                    qt_array = qt.split('-')
+                    qt = qt_array[0] + qt_array[1] + qt_array[2]
                 queue_date = datetime.datetime.strptime(qt, date_format)
         list.append(self, (input_art, queue_date, location))
 

--- a/tests/test_descriptors.py
+++ b/tests/test_descriptors.py
@@ -784,7 +784,7 @@ class TestQueuedArtifactList(TestCase):
         qart = self.get_queue_art('a2', 'A:2', 200000, datetime.timedelta(0, 3600))
         assert queued_artifacts[1] == qart
         qart = self.get_queue_art('a3', 'A:3', 50000, datetime.timedelta(0, 0))
-        assert queued_artifacts[1] == qart
+        assert queued_artifacts[2] == qart
 
     def test_set(self):
         queued_artifacts = QueuedArtifactList(self.instance1)

--- a/tests/test_descriptors.py
+++ b/tests/test_descriptors.py
@@ -750,6 +750,13 @@ class TestQueuedArtifactList(TestCase):
                 <value>A:2</value>
                 </location>
                 </artifact>
+                <artifact uri="{url}/artifacts/a3">
+                <queue-time>2011-12-25T01:10:10.050-00:00</queue-time>
+                <location>
+                <container uri="{url}/containers/c1"/>
+                <value>A:3</value>
+                </location>
+                </artifact>
                 </artifacts>
                 </test-entry>'''.format(url='http://testgenologics.com:4040/api/v2'))
 
@@ -776,10 +783,12 @@ class TestQueuedArtifactList(TestCase):
         assert queued_artifacts[0] == qart
         qart = self.get_queue_art('a2', 'A:2', 200000, datetime.timedelta(0, 3600))
         assert queued_artifacts[1] == qart
+        qart = self.get_queue_art('a3', 'A:3', 50000, datetime.timedelta(0, 0))
+        assert queued_artifacts[1] == qart
 
     def test_set(self):
         queued_artifacts = QueuedArtifactList(self.instance1)
-        qart = self.get_queue_art('a1', 'A:3',  50000, datetime.timedelta(0, 0))
+        qart = self.get_queue_art('a1', 'A:4',  50000, datetime.timedelta(0, 0))
         with pytest.raises(NotImplementedError):
             queued_artifacts.append(qart)
 


### PR DESCRIPTION
checked to see if '+' was in the string else used rules for parsing with '-'

closes [#21](https://github.com/EdinburghGenomics/pyclarity-lims/issues/21)