### PR TITLE
Added name attribute to ReagentType.

### DIFF
--- a/pyclarity_lims/entities.py
+++ b/pyclarity_lims/entities.py
@@ -1078,6 +1078,8 @@ class ReagentType(Entity):
     _TAG = "reagent-type"
     _PREFIX = 'rtp'
 
+    name = StringAttributeDescriptor("name")
+    """Name of the reagent type."""
     category = StringDescriptor('reagent-category')
     """Reagent category associated with the type"""
 


### PR DESCRIPTION
We needed to get the name of reagent types returned in the ReagentType class. It is there in the XML, it's just been missed from the class. It's just a "name" attribute added to the class.