### PR TITLE
Fix AttributeError in Lims.get

### DIFF
--- a/pyclarity_lims/lims.py
+++ b/pyclarity_lims/lims.py
@@ -91,7 +91,7 @@ class Lims(object):
                                          headers=dict(accept='application/xml'),
                                          timeout=TIMEOUT)
         except requests.exceptions.ConnectionError as e:
-            raise type(e)("{0}, Error trying to reach {1}".format(e.message, uri))
+            raise type(e)("{0}, Error trying to reach {1}".format(str(e), uri))
         else:
             return self.parse_response(r)
 


### PR DESCRIPTION
# Problem
Thank you for maintaining this tool! I just found one small bug. I was testing the behaviour of `lims.get(...)` when the connection was not possible (ie. bad URL or credentials) and was expecting a ConnectionError but got an AttributeError instead:
```
except requests.exceptions.ConnectionError as e:
    raise type(e)("{0}, Error trying to reach {1}".format(e.message, uri))
    AttributeError: 'ConnectionError' object has no attribute 'message'
```

# Environment
I was running Python 3.9 and requests==2.27.1

# Solution
I've changed it so that the ConnectionError is correctly raised.